### PR TITLE
Add Supabase auth API and hooks

### DIFF
--- a/src/hooks/useLogin.ts
+++ b/src/hooks/useLogin.ts
@@ -1,0 +1,31 @@
+import { useState } from 'react'
+
+export interface LoginResponse {
+  user?: unknown
+  session?: unknown
+  error?: string
+}
+
+export function useLogin() {
+  const [loading, setLoading] = useState(false)
+
+  const login = async (email: string, password: string): Promise<LoginResponse> => {
+    setLoading(true)
+    try {
+      const res = await fetch('http://localhost:3001/api/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = (await res.json()) as LoginResponse & { error?: string }
+      if (!res.ok) throw new Error(data.error)
+      return data
+    } catch (err: any) {
+      return { error: err.message }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { login, loading }
+}

--- a/src/hooks/useSignup.ts
+++ b/src/hooks/useSignup.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+export interface SignupResponse {
+  user?: unknown
+  error?: string
+}
+
+export function useSignup() {
+  const [loading, setLoading] = useState(false)
+
+  const signup = async (email: string, password: string): Promise<SignupResponse> => {
+    setLoading(true)
+    try {
+      const res = await fetch('http://localhost:3001/api/signup', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      })
+      const data = (await res.json()) as SignupResponse & { error?: string }
+      if (!res.ok) throw new Error(data.error)
+      return data
+    } catch (err: any) {
+      return { error: err.message }
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return { signup, loading }
+}

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -1,7 +1,7 @@
 import type React from "react";
 import { useState } from "react";
-import { useNavigate, Link, Navigate } from "react-router-dom";
-import { fine } from "@/lib/fine";
+import { useNavigate, Link } from "react-router-dom";
+import { useLogin } from "@/hooks/useLogin";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -56,6 +56,8 @@ export default function LoginForm() {
     return Object.keys(newErrors).length === 0;
   };
 
+  const { login } = useLogin();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -63,48 +65,23 @@ export default function LoginForm() {
 
     setIsLoading(true);
 
-    try {
-      const { data, error } = await fine.auth.signIn.email(
-        {
-          email: formData.email,
-          password: formData.password,
-          callbackURL: "/",
-          rememberMe: formData.rememberMe,
-        },
-        {
-          onRequest: () => {
-            setIsLoading(true);
-          },
-          onSuccess: () => {
-            toast({
-              title: "Success",
-              description: "You have been signed in successfully.",
-            });
-            navigate("/dashboard");
-          },
-          onError: (ctx) => {
-            toast({
-              title: "Error",
-              description: ctx.error.message,
-              variant: "destructive",
-            });
-          },
-        }
-      );
-    } catch (error: any) {
+    const result = await login(formData.email, formData.password);
+    if (result.error) {
       toast({
         title: "Error",
-        description: error.message || "Invalid email or password.",
+        description: result.error,
         variant: "destructive",
       });
-    } finally {
-      setIsLoading(false);
+    } else {
+      toast({
+        title: "Success",
+        description: "You have been signed in successfully.",
+      });
+      navigate("/dashboard");
     }
-  };
 
-  if (!fine) return <Navigate to='/dashboard' />;
-  const { isPending, data } = fine.auth.useSession();
-  if (!isPending && data) return <Navigate to='/dashboard' />;
+    setIsLoading(false);
+  };
 
   return (
     <div className='container mx-auto flex h-screen items-center justify-center py-10'>

--- a/src/pages/logout.tsx
+++ b/src/pages/logout.tsx
@@ -1,14 +1,13 @@
-import { fine } from "@/lib/fine";
 import { useEffect } from "react";
-import { Navigate } from "react-router-dom";
+import { useNavigate } from "react-router-dom";
 
 export default function Logout() {
-  if (!fine) return <Navigate to='/' />;
-
-  const { isPending, data } = fine.auth.useSession();
+  const navigate = useNavigate();
   useEffect(() => {
-    if (!isPending && data) fine.auth.signOut();
-  }, [data]);
+    fetch('http://localhost:3001/api/logout', { method: 'POST' }).finally(() => {
+      navigate('/login');
+    });
+  }, [navigate]);
 
-  return !isPending && !data ? <Navigate to='/login' /> : null;
+  return null;
 }

--- a/src/pages/signup.tsx
+++ b/src/pages/signup.tsx
@@ -1,8 +1,8 @@
 import type React from "react";
 
 import { useState } from "react";
-import { useNavigate, Link, Navigate } from "react-router-dom";
-import { fine } from "@/lib/fine";
+import { useNavigate, Link } from "react-router-dom";
+import { useSignup } from "@/hooks/useSignup";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -58,6 +58,8 @@ export default function SignupForm() {
     return Object.keys(newErrors).length === 0;
   };
 
+  const { signup } = useSignup();
+
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
@@ -65,52 +67,16 @@ export default function SignupForm() {
 
     setIsLoading(true);
 
-    try {
-      const { data, error } = await fine.auth.signUp.email(
-        {
-          email: formData.email,
-          password: formData.password,
-          name: formData.name,
-          callbackURL: "/",
-        },
-        {
-          onRequest: () => {
-            setIsLoading(true);
-          },
-          onSuccess: () => {
-            toast({
-              title: "Account created",
-              description: "Please check your email to verify your account.",
-            });
-            navigate("/login");
-          },
-          onError: (ctx) => {
-            toast({
-              title: "Error",
-              description: ctx.error.message,
-              variant: "destructive",
-            });
-          },
-        }
-      );
-
-      if (error) {
-        throw error;
-      }
-    } catch (error: any) {
-      toast({
-        title: "Error",
-        description: error.message || "Something went wrong. Please try again.",
-        variant: "destructive",
-      });
-    } finally {
-      setIsLoading(false);
+    const result = await signup(formData.email, formData.password);
+    if (result.error) {
+      toast({ title: "Error", description: result.error, variant: "destructive" });
+    } else {
+      toast({ title: "Account created", description: "Please check your email." });
+      navigate("/login");
     }
-  };
 
-  if (!fine) return <Navigate to='/dashboard' />;
-  const { isPending, data } = fine.auth.useSession();
-  if (!isPending && data) return <Navigate to='/dashboard' />;
+    setIsLoading(false);
+  };
 
   return (
     <div className='container mx-auto flex h-screen items-center justify-center py-10'>


### PR DESCRIPTION
## Summary
- implement Supabase signup/login/logout endpoints in `server.js`
- restrict CORS and listen on port 3001
- create React hooks `useLogin` and `useSignup`
- update login/signup/logout pages to call backend API

## Testing
- `npm run build` *(fails: cannot find type definitions)*

------
https://chatgpt.com/codex/tasks/task_e_6872e0b616f4832cb6e9f0e79d5ac96b